### PR TITLE
Add some always-includes to ensure that python3 works.

### DIFF
--- a/.sandstorm/sandstorm-pkgdef.capnp
+++ b/.sandstorm/sandstorm-pkgdef.capnp
@@ -81,8 +81,12 @@ const pkgdef :Spk.PackageDefinition = (
   alwaysInclude = [
                    "usr/local/lib/python2.7",
                    "usr/lib/python2.7",
-                   "usr/local/lib/python2.7",
-                   "usr/lib/python2.7",
+                   "usr/lib/pymodules",
+                   "usr/lib/pyshared",
+                   "usr/lib/python-tz",
+                   "usr/local/lib/python3.4",
+                   "usr/lib/python3.4",
+                   "usr/lib/python3",
                    "opt/sandstorm/latest/usr/include",
                   ],
 


### PR DESCRIPTION
Fixes #12.

Looks like @jparyani intended to do something like this in https://github.com/jparyani/ipython/commit/61e03b88072521c6727ad0ccd9581e596e348213.

python3 stats some files on startup, but does not actually open them unless they are needed. This made it so that python3 appeared to work without any problems under`vagrant-spk dev`,  but then failed to start at all in release mode, because the stat()ed files were not automatically included.

/usr/lib/python3 and /usr/lib/python3.4 are the directories that I needed to add to solve the problem (and they are the ones with the bulk of the new content), but I figured it would be good to include the other /usr/lib/py\* directories as well.

Note that after this change, the spk grows to ~ 178MB.
